### PR TITLE
[feat] Stock 도메인 Redisson 분산 락 기반 재고 감소 동시성 처리 적용

### DIFF
--- a/config/src/main/resources/config-repo/product-service.yml
+++ b/config/src/main/resources/config-repo/product-service.yml
@@ -11,8 +11,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
 
   jpa:
     hibernate:

--- a/config/src/main/resources/config-repo/product-service.yml
+++ b/config/src/main/resources/config-repo/product-service.yml
@@ -9,6 +9,10 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
   jpa:
     hibernate:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     networks:
       - hubeleven-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8761/actuator/health"]
+      test: [ "CMD", "curl", "-f", "http://localhost:8761/actuator/health" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -103,8 +103,8 @@ services:
       - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
       - SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.MySQL8Dialect
       - SPRING_JPA_HIBERNATE_DDL_AUTO=update
-      - SPRING_REDIS_HOST=${REDIS_HOST}
-      - SPRING_REDIS_PORT=${REDIS_PORT}
+      - SPRING_DATA_REDIS_HOST=${REDIS_HOST}
+      - SPRING_DATA_REDIS_PORT=${REDIS_PORT}
       - MANAGEMENT_ZIPKIN_TRACING_ENDPOINT=${ZIPKIN_ENDPOINT}
     depends_on:
       - eurekaServer

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+    // Redis / Redisson
+    implementation 'org.redisson:redisson:3.27.2'
+
     // External Libraries
     implementation 'com.github.ElevenHub:HubEleven-common:v0.0.1'
 

--- a/product/src/main/java/com/hubEleven/stock/application/port/StockLockManager.java
+++ b/product/src/main/java/com/hubEleven/stock/application/port/StockLockManager.java
@@ -1,0 +1,8 @@
+package com.hubEleven.stock.application.port;
+
+import java.util.function.Supplier;
+
+public interface StockLockManager {
+
+	<T> T executeWithLock(String lockKey, Supplier<T> supplier);
+}

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockDecreaseProcessor.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockDecreaseProcessor.java
@@ -1,0 +1,40 @@
+package com.hubEleven.stock.application.service;
+
+import static com.hubEleven.product.domain.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
+import static com.hubEleven.stock.domain.exception.StockErrorCode.STOCK_NOT_FOUND;
+
+import com.commonLib.common.exception.GlobalException;
+import com.hubEleven.product.domain.model.Product;
+import com.hubEleven.product.domain.repository.ProductRepository;
+import com.hubEleven.stock.application.dto.StockResult;
+import com.hubEleven.stock.domain.model.Stock;
+import com.hubEleven.stock.domain.repository.StockRepository;
+import com.hubEleven.stock.presentation.dto.request.StockRequests;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class StockDecreaseProcessor {
+
+	private final StockRepository stockRepository;
+	private final ProductRepository productRepository;
+
+	@Transactional
+	public StockResult decrease(StockRequests.Decrease request) {
+		Product product =
+				productRepository
+						.findByIdNotDeleted(request.productId())
+						.orElseThrow(() -> new GlobalException(PRODUCT_NOT_FOUND));
+
+		Stock stock =
+				stockRepository
+						.findByProductId(request.productId())
+						.orElseThrow(() -> new GlobalException(STOCK_NOT_FOUND));
+
+		stock.decreaseQuantity(request.quantity());
+
+		return StockResult.from(stock, product.getName());
+	}
+}

--- a/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
+++ b/product/src/main/java/com/hubEleven/stock/application/service/StockServiceImpl.java
@@ -7,6 +7,7 @@ import com.commonLib.common.exception.GlobalException;
 import com.hubEleven.product.domain.model.Product;
 import com.hubEleven.product.domain.repository.ProductRepository;
 import com.hubEleven.stock.application.dto.StockResult;
+import com.hubEleven.stock.application.port.StockLockManager;
 import com.hubEleven.stock.domain.model.Stock;
 import com.hubEleven.stock.domain.repository.StockRepository;
 import com.hubEleven.stock.presentation.dto.request.StockRequests;
@@ -21,6 +22,8 @@ public class StockServiceImpl implements StockService {
 
 	private final StockRepository stockRepository;
 	private final ProductRepository productRepository;
+	private final StockLockManager stockLockManager;
+	private final StockDecreaseProcessor stockDecreaseProcessor;
 
 	private Product getProductOrThrow(UUID productId) {
 		return productRepository
@@ -60,16 +63,9 @@ public class StockServiceImpl implements StockService {
 	}
 
 	@Override
-	@Transactional
 	public StockResult decreaseStock(StockRequests.Decrease request) {
-
-		Product product = getProductOrThrow(request.productId());
-
-		Stock stock = getStockOrThrow(request.productId());
-
-		stock.decreaseQuantity(request.quantity());
-
-		return StockResult.from(stock, product.getName());
+		return stockLockManager.executeWithLock(
+				"stock:decrease:" + request.productId(), () -> stockDecreaseProcessor.decrease(request));
 	}
 
 	@Override

--- a/product/src/main/java/com/hubEleven/stock/domain/exception/StockErrorCode.java
+++ b/product/src/main/java/com/hubEleven/stock/domain/exception/StockErrorCode.java
@@ -12,6 +12,7 @@ public enum StockErrorCode implements ErrorCode {
 	DECREASE_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "재고 감소 수량은 1 이상이어야 합니다."),
 	RESTORE_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "재고 복원 수량은 1 이상이어야 합니다."),
 	INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
+	STOCK_LOCK_TIMEOUT(HttpStatus.CONFLICT, "재고 감소 요청이 많아 잠시 후 다시 시도해 주세요."),
 	INITIAL_QUANTITY_INVALID(HttpStatus.BAD_REQUEST, "초기 재고 수량은 0 이상이어야 합니다.");
 
 	private final HttpStatus httpStatus;

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/configuration/RedissonConfig.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/configuration/RedissonConfig.java
@@ -1,0 +1,21 @@
+package com.hubEleven.stock.infrastructure.configuration;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	@Bean(destroyMethod = "shutdown")
+	public RedissonClient redissonClient(
+			@Value("${spring.data.redis.host:localhost}") String host,
+			@Value("${spring.data.redis.port:6379}") int port) {
+		Config config = new Config();
+		config.useSingleServer().setAddress("redis://" + host + ":" + port);
+		return Redisson.create(config);
+	}
+}

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/lock/RedissonStockLockManager.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/lock/RedissonStockLockManager.java
@@ -18,8 +18,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RedissonStockLockManager implements StockLockManager {
 
+	private static final int MAX_RETRY_COUNT = 3;
 	private static final long WAIT_TIME_SECONDS = 3L;
 	private static final long LEASE_TIME_SECONDS = 5L;
+	private static final long RETRY_BACKOFF_MILLIS = 100L;
 
 	private final RedissonClient redissonClient;
 
@@ -29,12 +31,16 @@ public class RedissonStockLockManager implements StockLockManager {
 		boolean locked = false;
 
 		try {
-			locked = lock.tryLock(WAIT_TIME_SECONDS, LEASE_TIME_SECONDS, TimeUnit.SECONDS);
-			if (!locked) {
-				throw new GlobalException(STOCK_LOCK_TIMEOUT);
+			for (int retryCount = 0; retryCount < MAX_RETRY_COUNT; retryCount++) {
+				locked = lock.tryLock(WAIT_TIME_SECONDS, LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+				if (locked) {
+					return supplier.get();
+				}
+
+				Thread.sleep(RETRY_BACKOFF_MILLIS);
 			}
 
-			return supplier.get();
+			throw new GlobalException(STOCK_LOCK_TIMEOUT);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			throw new GlobalException(STOCK_LOCK_TIMEOUT);

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/lock/RedissonStockLockManager.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/lock/RedissonStockLockManager.java
@@ -2,17 +2,14 @@ package com.hubEleven.stock.infrastructure.lock;
 
 import static com.hubEleven.stock.domain.exception.StockErrorCode.STOCK_LOCK_TIMEOUT;
 
+import com.commonLib.common.exception.GlobalException;
+import com.hubEleven.stock.application.port.StockLockManager;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
+import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
-
-import com.commonLib.common.exception.GlobalException;
-import com.hubEleven.stock.application.port.StockLockManager;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/product/src/main/java/com/hubEleven/stock/infrastructure/lock/RedissonStockLockManager.java
+++ b/product/src/main/java/com/hubEleven/stock/infrastructure/lock/RedissonStockLockManager.java
@@ -1,0 +1,47 @@
+package com.hubEleven.stock.infrastructure.lock;
+
+import static com.hubEleven.stock.domain.exception.StockErrorCode.STOCK_LOCK_TIMEOUT;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import com.commonLib.common.exception.GlobalException;
+import com.hubEleven.stock.application.port.StockLockManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedissonStockLockManager implements StockLockManager {
+
+	private static final long WAIT_TIME_SECONDS = 3L;
+	private static final long LEASE_TIME_SECONDS = 5L;
+
+	private final RedissonClient redissonClient;
+
+	@Override
+	public <T> T executeWithLock(String lockKey, Supplier<T> supplier) {
+		RLock lock = redissonClient.getLock(lockKey);
+		boolean locked = false;
+
+		try {
+			locked = lock.tryLock(WAIT_TIME_SECONDS, LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+			if (!locked) {
+				throw new GlobalException(STOCK_LOCK_TIMEOUT);
+			}
+
+			return supplier.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new GlobalException(STOCK_LOCK_TIMEOUT);
+		} finally {
+			if (locked && lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
+		}
+	}
+}

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -5,8 +5,6 @@ spring:
     redis:
       host: ${SPRING_DATA_REDIS_HOST:localhost}
       port: ${SPRING_DATA_REDIS_PORT:6379}
-  config:
-    import: "optional:configserver:"
   cloud:
     config:
       discovery:
@@ -21,3 +19,25 @@ eureka:
       defaultZone: http://localhost:8761/eureka/
   instance:
     instance-id: ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}
+
+---
+# Product Profile
+spring:
+  config:
+    activate:
+      on-profile: prod
+    import: "configserver:"
+
+---
+# Test Profile
+spring:
+  config:
+    activate:
+      on-profile: test
+  cloud:
+    config:
+      enabled: false
+
+eureka:
+  client:
+    enabled: false

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: product-service
   config:
-    import: "configserver:"
+    import: "optional:configserver:"
   cloud:
     config:
       discovery:

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: product-service
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   config:
     import: "optional:configserver:"
   cloud:

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -3,8 +3,8 @@ spring:
     name: product-service
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
   config:
     import: "optional:configserver:"
   cloud:

--- a/product/src/test/java/com/hubEleven/product/ProductApplicationTests.java
+++ b/product/src/test/java/com/hubEleven/product/ProductApplicationTests.java
@@ -2,8 +2,10 @@ package com.hubEleven.product;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class ProductApplicationTests {
 
 	@Test

--- a/product/src/test/java/com/hubEleven/product/stock/application/fixtures/ProductFixture.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/fixtures/ProductFixture.java
@@ -5,22 +5,17 @@ import java.util.UUID;
 
 public class ProductFixture {
 
-    // ===== ID =====
+	// ===== ID =====
 
-    public static final UUID COMPANY_ID = UUID.randomUUID();
+	public static final UUID COMPANY_ID = UUID.randomUUID();
 
-    public static final UUID HUB_ID = UUID.randomUUID();
+	public static final UUID HUB_ID = UUID.randomUUID();
 
-    // ===== Factory Methods =====
+	// ===== Factory Methods =====
 
-    public static Product createDefault() {
-        return Product.create(
-                "Default Product",
-                COMPANY_ID,
-                HUB_ID
-        );
-    }
+	public static Product createDefault() {
+		return Product.create("Default Product", COMPANY_ID, HUB_ID);
+	}
 
-    private ProductFixture() {
-    }
+	private ProductFixture() {}
 }

--- a/product/src/test/java/com/hubEleven/product/stock/application/fixtures/ProductFixture.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/fixtures/ProductFixture.java
@@ -1,0 +1,26 @@
+package com.hubEleven.product.stock.application.fixtures;
+
+import com.hubEleven.product.domain.model.Product;
+import java.util.UUID;
+
+public class ProductFixture {
+
+    // ===== ID =====
+
+    public static final UUID COMPANY_ID = UUID.randomUUID();
+
+    public static final UUID HUB_ID = UUID.randomUUID();
+
+    // ===== Factory Methods =====
+
+    public static Product createDefault() {
+        return Product.create(
+                "Default Product",
+                COMPANY_ID,
+                HUB_ID
+        );
+    }
+
+    private ProductFixture() {
+    }
+}

--- a/product/src/test/java/com/hubEleven/product/stock/application/fixtures/StockFixture.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/fixtures/StockFixture.java
@@ -1,0 +1,29 @@
+package com.hubEleven.product.stock.application.fixtures;
+
+import com.hubEleven.product.domain.model.Product;
+import com.hubEleven.stock.domain.model.Stock;
+import com.hubEleven.stock.presentation.dto.request.StockRequests;
+
+public class StockFixture {
+
+    // ===== Factory Methods =====
+
+    public static Stock createFromProductWithQuantity(Product product, int quantity) {
+        return Stock.create(
+                product.getProductId(),
+                product.getCompanyId(),
+                product.getHubId(),
+                quantity
+        );
+    }
+
+    public static StockRequests.Decrease decreaseRequest(Product product, int quantity) {
+        return new StockRequests.Decrease(
+                product.getProductId(),
+                quantity
+        );
+    }
+
+    private StockFixture() {
+    }
+}

--- a/product/src/test/java/com/hubEleven/product/stock/application/fixtures/StockFixture.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/fixtures/StockFixture.java
@@ -6,24 +6,16 @@ import com.hubEleven.stock.presentation.dto.request.StockRequests;
 
 public class StockFixture {
 
-    // ===== Factory Methods =====
+	// ===== Factory Methods =====
 
-    public static Stock createFromProductWithQuantity(Product product, int quantity) {
-        return Stock.create(
-                product.getProductId(),
-                product.getCompanyId(),
-                product.getHubId(),
-                quantity
-        );
-    }
+	public static Stock createFromProductWithQuantity(Product product, int quantity) {
+		return Stock.create(
+				product.getProductId(), product.getCompanyId(), product.getHubId(), quantity);
+	}
 
-    public static StockRequests.Decrease decreaseRequest(Product product, int quantity) {
-        return new StockRequests.Decrease(
-                product.getProductId(),
-                quantity
-        );
-    }
+	public static StockRequests.Decrease decreaseRequest(Product product, int quantity) {
+		return new StockRequests.Decrease(product.getProductId(), quantity);
+	}
 
-    private StockFixture() {
-    }
+	private StockFixture() {}
 }

--- a/product/src/test/java/com/hubEleven/product/stock/application/service/StockConcurrencyTest.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/service/StockConcurrencyTest.java
@@ -2,13 +2,19 @@ package com.hubEleven.product.stock.application.service;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.hubEleven.product.domain.model.Product;
+import com.hubEleven.product.infrastructure.repository.JpaProductRepository;
+import com.hubEleven.product.stock.application.fixtures.ProductFixture;
+import com.hubEleven.product.stock.application.fixtures.StockFixture;
+import com.hubEleven.stock.application.service.StockServiceImpl;
+import com.hubEleven.stock.domain.model.Stock;
+import com.hubEleven.stock.infrastructure.repository.JpaStockRepository;
 import java.util.Queue;
-import java.util.stream.Collectors;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,26 +23,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.hubEleven.product.domain.model.Product;
-import com.hubEleven.product.infrastructure.repository.JpaProductRepository;
-import com.hubEleven.product.stock.application.fixtures.ProductFixture;
-import com.hubEleven.product.stock.application.fixtures.StockFixture;
-import com.hubEleven.stock.application.service.StockServiceImpl;
-import com.hubEleven.stock.domain.model.Stock;
-import com.hubEleven.stock.infrastructure.repository.JpaStockRepository;
-
 @ActiveProfiles("test")
 @SpringBootTest
 public class StockConcurrencyTest {
 
-	@Autowired
-	private StockServiceImpl stockServiceImpl;
+	@Autowired private StockServiceImpl stockServiceImpl;
 
-	@Autowired
-	private JpaStockRepository jpaStockRepository;
+	@Autowired private JpaStockRepository jpaStockRepository;
 
-	@Autowired
-	private JpaProductRepository jpaProductRepository;
+	@Autowired private JpaProductRepository jpaProductRepository;
 
 	private Product product;
 
@@ -72,17 +67,17 @@ public class StockConcurrencyTest {
 		// when
 		for (int i = 0; i < threadCount; i++) {
 			executorService.submit(
-				() -> {
-					try {
-						readyLatch.countDown();
-						startLatch.await();
-						stockServiceImpl.decreaseStock(StockFixture.decreaseRequest(product, 1));
-					} catch (Throwable e) {
-						exceptions.add(e);
-					} finally {
-						doneLatch.countDown();
-					}
-				});
+					() -> {
+						try {
+							readyLatch.countDown();
+							startLatch.await();
+							stockServiceImpl.decreaseStock(StockFixture.decreaseRequest(product, 1));
+						} catch (Throwable e) {
+							exceptions.add(e);
+						} finally {
+							doneLatch.countDown();
+						}
+					});
 		}
 
 		readyLatch.await();
@@ -99,7 +94,7 @@ public class StockConcurrencyTest {
 
 	private String exceptionMessages(Queue<Throwable> exceptions) {
 		return exceptions.stream()
-			.map(throwable -> throwable.getClass().getName() + ": " + throwable.getMessage())
-			.collect(Collectors.joining(System.lineSeparator()));
+				.map(throwable -> throwable.getClass().getName() + ": " + throwable.getMessage())
+				.collect(Collectors.joining(System.lineSeparator()));
 	}
 }

--- a/product/src/test/java/com/hubEleven/product/stock/application/service/StockConcurrencyTest.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/service/StockConcurrencyTest.java
@@ -1,0 +1,105 @@
+package com.hubEleven.product.stock.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Queue;
+import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.hubEleven.product.domain.model.Product;
+import com.hubEleven.product.infrastructure.repository.JpaProductRepository;
+import com.hubEleven.product.stock.application.fixtures.ProductFixture;
+import com.hubEleven.product.stock.application.fixtures.StockFixture;
+import com.hubEleven.stock.application.service.StockServiceImpl;
+import com.hubEleven.stock.domain.model.Stock;
+import com.hubEleven.stock.infrastructure.repository.JpaStockRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class StockConcurrencyTest {
+
+	@Autowired
+	private StockServiceImpl stockServiceImpl;
+
+	@Autowired
+	private JpaStockRepository jpaStockRepository;
+
+	@Autowired
+	private JpaProductRepository jpaProductRepository;
+
+	private Product product;
+
+	@BeforeEach
+	void setUp() {
+		product = ProductFixture.createDefault();
+		jpaProductRepository.saveAndFlush(product);
+
+		Stock stock = StockFixture.createFromProductWithQuantity(product, 100);
+		jpaStockRepository.saveAndFlush(stock);
+	}
+
+	@AfterEach
+	void tearDown() {
+		jpaStockRepository.deleteAll();
+		jpaProductRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("재고 감소 - 100개 동시 요청 시 정확히 차감")
+	void decreaseStock_when100ConcurrentRequests_thenSuccess() throws Exception {
+
+		// given
+		int threadCount = 100;
+
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+		CountDownLatch readyLatch = new CountDownLatch(threadCount);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(threadCount);
+		Queue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(
+				() -> {
+					try {
+						readyLatch.countDown();
+						startLatch.await();
+						stockServiceImpl.decreaseStock(StockFixture.decreaseRequest(product, 1));
+					} catch (Throwable e) {
+						exceptions.add(e);
+					} finally {
+						doneLatch.countDown();
+					}
+				});
+		}
+
+		readyLatch.await();
+		startLatch.countDown();
+		doneLatch.await();
+		executorService.shutdown();
+
+		// then
+		Stock updatedStock = jpaStockRepository.findByProductId(product.getProductId()).orElseThrow();
+
+		assertTrue(exceptions.isEmpty(), exceptionMessages(exceptions));
+		assertEquals(0, updatedStock.getQuantity());
+	}
+
+	private String exceptionMessages(Queue<Throwable> exceptions) {
+		return exceptions.stream()
+			.map(throwable -> throwable.getClass().getName() + ": " + throwable.getMessage())
+			.collect(Collectors.joining(System.lineSeparator()));
+	}
+}

--- a/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
@@ -1,0 +1,74 @@
+package com.hubEleven.product.stock.application.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hubEleven.product.domain.model.Product;
+import com.hubEleven.product.infrastructure.repository.JpaProductRepository;
+import com.hubEleven.product.stock.application.fixtures.ProductFixture;
+import com.hubEleven.product.stock.application.fixtures.StockFixture;
+import com.hubEleven.stock.application.dto.StockResult;
+import com.hubEleven.stock.application.service.StockServiceImpl;
+import com.hubEleven.stock.domain.model.Stock;
+import com.hubEleven.stock.infrastructure.repository.JpaStockRepository;
+import com.hubEleven.stock.presentation.dto.request.StockRequests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class StockServiceImplTest {
+
+    @Autowired
+    private StockServiceImpl stockServiceImpl;
+
+    @Autowired
+    private JpaStockRepository jpaStockRepository;
+
+    @Autowired
+    private JpaProductRepository jpaProductRepository;
+
+    private Product product;
+
+    // 테스트 전 상품 재고 입력
+    @BeforeEach
+    public void setUp() {
+
+        product = ProductFixture.createDefault();
+        jpaProductRepository.saveAndFlush(product);
+
+        Stock stock = StockFixture.createFromProductWithQuantity(product, 100);
+        jpaStockRepository.saveAndFlush(stock);
+    }
+
+    @AfterEach
+    public void after() {
+        jpaStockRepository.deleteAll();
+        jpaProductRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("재고 감소 - 단일 요청 성공")
+    void decreaseStock_success() {
+
+        // given
+        int decreaseAmount = 10;
+
+        StockRequests.Decrease request = StockFixture.decreaseRequest(
+                product, decreaseAmount);
+
+        // when
+        StockResult result = stockServiceImpl.decreaseStock(request);
+
+        // then - 반환값 검증
+        assertThat(result.productId()).isEqualTo(product.getProductId());
+        assertThat(result.companyId()).isEqualTo(product.getCompanyId());
+        assertThat(result.hubId()).isEqualTo(product.getHubId());
+        assertThat(result.quantity()).isEqualTo(90);
+    }
+}

--- a/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
@@ -2,14 +2,6 @@ package com.hubEleven.product.stock.application.service;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-
 import com.hubEleven.product.domain.model.Product;
 import com.hubEleven.product.infrastructure.repository.JpaProductRepository;
 import com.hubEleven.product.stock.application.fixtures.ProductFixture;
@@ -19,19 +11,23 @@ import com.hubEleven.stock.application.service.StockServiceImpl;
 import com.hubEleven.stock.domain.model.Stock;
 import com.hubEleven.stock.infrastructure.repository.JpaStockRepository;
 import com.hubEleven.stock.presentation.dto.request.StockRequests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
 class StockServiceImplTest {
 
-	@Autowired
-	private StockServiceImpl stockServiceImpl;
+	@Autowired private StockServiceImpl stockServiceImpl;
 
-	@Autowired
-	private JpaStockRepository jpaStockRepository;
+	@Autowired private JpaStockRepository jpaStockRepository;
 
-	@Autowired
-	private JpaProductRepository jpaProductRepository;
+	@Autowired private JpaProductRepository jpaProductRepository;
 
 	private Product product;
 

--- a/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
@@ -1,6 +1,14 @@
 package com.hubEleven.product.stock.application.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.hubEleven.product.domain.model.Product;
 import com.hubEleven.product.infrastructure.repository.JpaProductRepository;
@@ -11,23 +19,19 @@ import com.hubEleven.stock.application.service.StockServiceImpl;
 import com.hubEleven.stock.domain.model.Stock;
 import com.hubEleven.stock.infrastructure.repository.JpaStockRepository;
 import com.hubEleven.stock.presentation.dto.request.StockRequests;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
 class StockServiceImplTest {
 
-	@Autowired private StockServiceImpl stockServiceImpl;
+	@Autowired
+	private StockServiceImpl stockServiceImpl;
 
-	@Autowired private JpaStockRepository jpaStockRepository;
+	@Autowired
+	private JpaStockRepository jpaStockRepository;
 
-	@Autowired private JpaProductRepository jpaProductRepository;
+	@Autowired
+	private JpaProductRepository jpaProductRepository;
 
 	private Product product;
 

--- a/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
+++ b/product/src/test/java/com/hubEleven/product/stock/application/service/StockServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.hubEleven.product.stock.application.service;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hubEleven.product.domain.model.Product;
@@ -24,51 +23,47 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 class StockServiceImplTest {
 
-    @Autowired
-    private StockServiceImpl stockServiceImpl;
+	@Autowired private StockServiceImpl stockServiceImpl;
 
-    @Autowired
-    private JpaStockRepository jpaStockRepository;
+	@Autowired private JpaStockRepository jpaStockRepository;
 
-    @Autowired
-    private JpaProductRepository jpaProductRepository;
+	@Autowired private JpaProductRepository jpaProductRepository;
 
-    private Product product;
+	private Product product;
 
-    // 테스트 전 상품 재고 입력
-    @BeforeEach
-    public void setUp() {
+	// 테스트 전 상품 재고 입력
+	@BeforeEach
+	public void setUp() {
 
-        product = ProductFixture.createDefault();
-        jpaProductRepository.saveAndFlush(product);
+		product = ProductFixture.createDefault();
+		jpaProductRepository.saveAndFlush(product);
 
-        Stock stock = StockFixture.createFromProductWithQuantity(product, 100);
-        jpaStockRepository.saveAndFlush(stock);
-    }
+		Stock stock = StockFixture.createFromProductWithQuantity(product, 100);
+		jpaStockRepository.saveAndFlush(stock);
+	}
 
-    @AfterEach
-    public void after() {
-        jpaStockRepository.deleteAll();
-        jpaProductRepository.deleteAll();
-    }
+	@AfterEach
+	public void after() {
+		jpaStockRepository.deleteAll();
+		jpaProductRepository.deleteAll();
+	}
 
-    @Test
-    @DisplayName("재고 감소 - 단일 요청 성공")
-    void decreaseStock_success() {
+	@Test
+	@DisplayName("재고 감소 - 단일 요청 성공")
+	void decreaseStock_success() {
 
-        // given
-        int decreaseAmount = 10;
+		// given
+		int decreaseAmount = 10;
 
-        StockRequests.Decrease request = StockFixture.decreaseRequest(
-                product, decreaseAmount);
+		StockRequests.Decrease request = StockFixture.decreaseRequest(product, decreaseAmount);
 
-        // when
-        StockResult result = stockServiceImpl.decreaseStock(request);
+		// when
+		StockResult result = stockServiceImpl.decreaseStock(request);
 
-        // then - 반환값 검증
-        assertThat(result.productId()).isEqualTo(product.getProductId());
-        assertThat(result.companyId()).isEqualTo(product.getCompanyId());
-        assertThat(result.hubId()).isEqualTo(product.getHubId());
-        assertThat(result.quantity()).isEqualTo(90);
-    }
+		// then - 반환값 검증
+		assertThat(result.productId()).isEqualTo(product.getProductId());
+		assertThat(result.companyId()).isEqualTo(product.getCompanyId());
+		assertThat(result.hubId()).isEqualTo(product.getHubId());
+		assertThat(result.quantity()).isEqualTo(90);
+	}
 }

--- a/product/src/test/resources/application-test.yml
+++ b/product/src/test/resources/application-test.yml
@@ -16,6 +16,10 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 eureka:
   client:

--- a/product/src/test/resources/application-test.yml
+++ b/product/src/test/resources/application-test.yml
@@ -1,0 +1,22 @@
+spring:
+  config:
+    import: "optional:file:.env[.properties],optional:file:../.env[.properties]"
+  cloud:
+    config:
+      enabled: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/hubeleven_test?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
+eureka:
+  client:
+    enabled: false


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #1 

<br>

## 📌 개요
- Stock 도메인의 재고 감소 로직(`decreaseStock`)에서 동시 주문 요청 시 발생할 수 있는 재고 정합성 문제를 테스트로 재현하고, Redisson 기반 분산 락을 적용했습니다.
- 동일 상품 재고 감소 요청을 상품 ID 기반 lock key로 직렬화하여 분산 환경에서도 lost update 문제가 발생하지 않도록 개선했습니다.
- 단순 락 적용 후 트랜잭션 커밋보다 락 해제가 먼저 일어날 수 있는 문제를 확인하고, 실제 재고 감소 트랜잭션을 별도 Processor로 분리하여 락 해제 순서를 개선했습니다.
- 락 획득 실패 시 즉시 실패하지 않고 제한적으로(3회) 재시도한 뒤, 최종 실패 시 명시적인 예외를 반환하도록 처리했습니다.

<br>

## 🔁 변경 사항

- 재고 감소 동시 요청 테스트 추가
  - 동일 상품 재고 100개에 대해 100개의 스레드가 동시에 1개씩 감소 요청하는 테스트를 추가했습니다.
  - `CountDownLatch`를 사용해 다수의 스레드가 최대한 동시에 요청을 시작하도록 구성했습니다.
  - Redisson 적용 전 현재 구현에서 최종 재고가 기대값과 달라지는 race condition을 확인했습니다.

- Redisson 기반 분산 락 적용
  - `RedissonClient` 설정을 추가하고 Redis host/port를 설정값으로 분리했습니다.
  - `StockLockManager` 인터페이스를 추가해 재고 서비스가 Redisson 구현체에 직접 의존하지 않도록 분리했습니다.
  - `RedissonStockLockManager`를 통해 상품별 lock key 기반 분산 락을 적용했습니다.
  - lock key 형식: `stock:decrease:{productId}`

- 재고 감소 트랜잭션 분리
  - 기존 단순 락 적용 구조에서는 `@Transactional` 메서드 내부에서 락을 획득/해제하여, 락 해제가 DB commit보다 먼저 일어날 수 있는 문제가 있었습니다.
  - 이를 해결하기 위해 실제 재고 감소 DB 작업을 `StockDecreaseProcessor`로 분리했습니다.
  - 최종 흐름을 `락 획득 → 재고 감소 트랜잭션 실행/커밋 → 락 해제` 구조로 개선했습니다.

- 락 획득 실패 처리 개선
  - 락 획득 실패 시 최대 3회까지 재시도하도록 처리했습니다.
  - 재시도 후에도 락을 획득하지 못하면 `STOCK_LOCK_TIMEOUT` 예외를 반환합니다.
  - 이를 통해 호출 측에서 재시도 여부를 판단할 수 있도록 명확한 실패 응답을 제공합니다.

<br>

## 📸 스크린샷

<details>
  <summary>테스트 통과</summary>

<img width="1348" height="796" alt="Screenshot 2026-06-16 at 11 42 46 PM" src="https://github.com/user-attachments/assets/dc479e9b-f0aa-42bf-a99e-48d6d654f096" />

</details>

