### PR TITLE
[docs] GitHub Copilot 코드 리뷰 응답 지침 md 파일 추가

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# GitHub Copilot Instructions
+
+## Language Rule
+
+- **Always respond in Korean.**
+- Regardless of the input language, always reply in Korean.
+
+## Code Review Rule
+
+- When reviewing code or proposing code changes, **a `suggestion` block must always be included.**
+- Do not provide only explanations — **always include actual code changes using a `suggestion` block.**
+- A `suggestion` block must contain **code only**.
+- Any explanation must be written **outside** the `suggestion` block.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@
 
 - **Always respond in Korean.**
 - Regardless of the input language, always reply in Korean.
+- When using technical terminology, include the original English term where appropriate.
 
 ## Code Review Rule
 
@@ -11,3 +12,6 @@
 - Do not provide only explanations — **always include actual code changes using a `suggestion` block.**
 - A `suggestion` block must contain **code only**.
 - Any explanation must be written **outside** the `suggestion` block.
+- When identifying an issue, clearly explain its location, cause, potential impact, and recommended solution.
+- Do not make review comments based on unsupported assumptions.
+- Do not leave review comments that merely summarize the code changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,8 +9,8 @@
 
 ## Code Review Rule
 
-- When reviewing code or proposing code changes, **a `suggestion` block must always be included.**
-- Do not provide only explanations — **always include actual code changes using a `suggestion` block.**
+- When reviewing code or proposing code changes, include a `suggestion` block **when the fix is small, self-contained, and safe to apply as-is**.
+- If the fix requires broader context (e.g., multi-file changes, architectural decisions, or uncertainty), provide a clear explanation and recommended approach **without** a `suggestion` block.
 - A `suggestion` block must contain **code only**.
 - Any explanation must be written **outside** the `suggestion` block.
 - When identifying an issue, clearly explain its location, cause, potential impact, and recommended solution.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,7 @@
 - **Always respond in Korean.**
 - Regardless of the input language, always reply in Korean.
 - When using technical terminology, include the original English term where appropriate.
+- Do not translate code identifiers (e.g., function/variable names), API names, logs, or error messages; keep them as-is unless a translation is explicitly needed for explanation.
 
 ## Code Review Rule
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타 사소한 수정

<br>

## ❗️ 관련 이슈 링크
Close #3 

<br>

## 📌 개요
- GitHub Copilot 코드 리뷰가 한국어로 작성되도록 저장소 공통 지침을 추가했습니다.
- 리뷰 의견에 문제의 원인, 영향 및 개선 방법이 포함되도록 작성 규칙을 정의했습니다.

<br>

## 🔁 변경 사항
- `.github/copilot-instructions.md` 파일을 추가했습니다.
- Copilot 코드 리뷰 답변 언어를 한국어로 지정했습니다.
- 기술 용어가 필요한 경우 영어 원문을 함께 표기하도록 설정했습니다.
- 문제를 발견한 경우 문제 위치, 원인, 예상 영향 및 개선 방법을 구체적으로 설명하도록 설정했습니다.
- 근거 없는 추측이나 단순한 변경 사항 요약을 리뷰 의견으로 작성하지 않도록 설정했습니다.

<br>

## 👀 기타 더 이야기해볼 점
- Copilot은 PR의 대상 브랜치에 존재하는 지침을 사용합니다.
- 따라서 해당 파일이 대상 브랜치에 병합된 이후 생성되는 PR부터 적용 여부를 확인할 수 있습니다.
- 참고 자료 : https://velog.io/@sunz8281/make-copilot-use-korean

